### PR TITLE
fix: update paths to `honeycombio` 🍯

### DIFF
--- a/.grit/grit.yaml
+++ b/.grit/grit.yaml
@@ -1,6 +1,6 @@
 version: 0.0.1
 patterns:
-  - name: github.com/getgrit/stdlib#*
+  - name: github.com/honeycombio/stdlib#*
   - name: use_ubuntu
     description: 'This is a no-op warning meant for testing. You can ignore it.'
     level: warn

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ You can add it as a step in your GitHub Actions workflow to automatically check 
 
 ```
   - name: Grit
-    uses: getgrit/github-action-check@v0
+    uses: honeycombio/github-action-check@v0
     with:
       # Optional additional arguments to pass to the `grit check` command
       args: ''
@@ -25,7 +25,7 @@ By default, only warning and error patterns are reported. To include info patter
 
 ```
   - name: Grit
-    uses: getgrit/github-action-check@v0
+    uses: honeycombio/github-action-check@v0
     with:
       args: '--level info'
 ```
@@ -50,7 +50,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v4
       - name: grit-check
-        uses: getgrit/github-action-check@v0
+        uses: honeycombio/github-action-check@v0
 ```
 
 ## License


### PR DESCRIPTION
Starting [from yesterday](https://www.honeycomb.io/blog/honeycomb-acquires-grit), the import paths changed from `getgrit/github-action-check` to `honeycombio/github-action-check`.

This PR updates the documentation to reflect this change.